### PR TITLE
[Linux] uWSGI: Fix permission denied on subprocess.getoutput

### DIFF
--- a/browsers/linux.py
+++ b/browsers/linux.py
@@ -44,7 +44,7 @@ def browsers() -> Iterator[Browser]:  # type: ignore[return]
                     executable_path = entry.getExec()
                     if executable_path.lower().endswith(" %u"):
                         executable_path = executable_path[:-3].strip()
-                    version = subprocess.getoutput(f"{executable_path} --version 2>&1").strip()
+                    version = subprocess.check_output([executable_path, "--version"]).decode().strip()
                     match = VERSION_PATTERN.search(version)
                     if match:
                         version = match[0]

--- a/browsers/linux.py
+++ b/browsers/linux.py
@@ -44,7 +44,7 @@ def browsers() -> Iterator[Browser]:  # type: ignore[return]
                     executable_path = entry.getExec()
                     if executable_path.lower().endswith(" %u"):
                         executable_path = executable_path[:-3].strip()
-                    version = subprocess.check_output([executable_path, "--version"]).decode().strip()
+                    version = subprocess.check_output([executable_path, "--version", "2>&1"]).decode().strip()
                     match = VERSION_PATTERN.search(version)
                     if match:
                         version = match[0]


### PR DESCRIPTION
Using uWSGI on Linux, Python fails to call subprocess.getoutput method due to a permissions problem.

```
mkdir: cannot create directory '/.local': Permission denied
touch: cannot touch '/.local/share/applications/mimeapps.list': No such file or directory
```
Using the subprocess.check_output method, no directory creation request is made and the command returns the expected value

To be tested on other OS