### PR TITLE
✨ Support Firefox-based browsers

### DIFF
--- a/browsers/linux.py
+++ b/browsers/linux.py
@@ -9,6 +9,9 @@ from .common import Browser
 
 LINUX_DESKTOP_ENTRY_LIST = (
     # desktop entry name can be "firefox.desktop" or "firefox_firefox.desktop"
+    ("brave", ("brave-browser", "brave_brave")),
+    ("brave-beta", ("brave-browser-beta",)),
+    ("brave-nightly", ("brave-browser-nightly",)),
     ("chrome", ("google-chrome",)),
     ("chromium", ("chromium", "chromium_chromium")),
     ("firefox", ("firefox", "firefox_firefox")),
@@ -16,9 +19,6 @@ LINUX_DESKTOP_ENTRY_LIST = (
     ("opera", ("opera_opera",)),
     ("opera-beta", ("opera-beta_opera-beta",)),
     ("opera-developer", ("opera-developer_opera-developer",)),
-    ("brave", ("brave-browser", "brave_brave")),
-    ("brave-beta", ("brave-browser-beta",)),
-    ("brave-nightly", ("brave-browser-nightly",)),
 )
 
 # $XDG_DATA_HOME and $XDG_DATA_DIRS are not always set

--- a/browsers/osx.py
+++ b/browsers/osx.py
@@ -9,6 +9,11 @@ from .common import Browser
 
 OSX_BROWSER_BUNDLE_LIST = (
     # browser name, bundle ID, version string
+    ("basilisk", "org.mozilla.basilisk", "CFBundleShortVersionString"),
+    ("brave", "com.brave.Browser", "CFBundleVersion"),
+    ("brave-beta", "com.brave.Browser.beta", "CFBundleVersion"),
+    ("brave-dev", "com.brave.Browser.dev", "CFBundleVersion"),
+    ("brave-nightly", "com.brave.Browser.nightly", "CFBundleVersion"),
     ("chrome", "com.google.Chrome", "CFBundleShortVersionString"),
     ("chrome-canary", "com.google.Chrome.canary", "CFBundleShortVersionString"),
     ("chrome-test", "com.google.chrome.for.testing", "CFBundleShortVersionString"),
@@ -16,18 +21,18 @@ OSX_BROWSER_BUNDLE_LIST = (
     ("firefox", "org.mozilla.firefox", "CFBundleShortVersionString"),
     ("firefox-developer", "org.mozilla.firefoxdeveloperedition", "CFBundleShortVersionString"),
     ("firefox-nightly", "org.mozilla.nightly", "CFBundleShortVersionString"),
-    ("safari", "com.apple.Safari", "CFBundleShortVersionString"),
-    ("opera", "com.operasoftware.Opera", "CFBundleVersion"),
-    ("opera-beta", "com.operasoftware.OperaNext", "CFBundleVersion"),
-    ("opera-developer", "com.operasoftware.OperaDeveloper", "CFBundleVersion"),
+    ("floorp", "org.mozilla.floorp", "CFBundleShortVersionString"),
+    ("librewolf", "org.mozilla.librewolf", "CFBundleShortVersionString"),
     ("msedge", "com.microsoft.edgemac", "CFBundleShortVersionString"),
     ("msedge-beta", "com.microsoft.edgemac.Beta", "CFBundleShortVersionString"),
     ("msedge-dev", "com.microsoft.edgemac.Dev", "CFBundleShortVersionString"),
     ("msedge-canary", "com.microsoft.edgemac.Canary", "CFBundleShortVersionString"),
-    ("brave", "com.brave.Browser", "CFBundleVersion"),
-    ("brave-beta", "com.brave.Browser.beta", "CFBundleVersion"),
-    ("brave-dev", "com.brave.Browser.dev", "CFBundleVersion"),
-    ("brave-nightly", "com.brave.Browser.nightly", "CFBundleVersion"),
+    ("opera", "com.operasoftware.Opera", "CFBundleVersion"),
+    ("opera-beta", "com.operasoftware.OperaNext", "CFBundleVersion"),
+    ("opera-developer", "com.operasoftware.OperaDeveloper", "CFBundleVersion"),
+    ("pale-moon", "org.mozilla.pale moon", "CFBundleShortVersionString"),
+    ("safari", "com.apple.Safari", "CFBundleShortVersionString"),
+    ("waterfox", "net.waterfox.waterfox", "CFBundleShortVersionString"),
 )
 
 OSX_BROWSER_BUNDLE_DICT = {item[1]: item for item in OSX_BROWSER_BUNDLE_LIST}

--- a/browsers/windows.py
+++ b/browsers/windows.py
@@ -8,23 +8,28 @@ from typing import Iterator
 from .common import Browser
 
 WINDOWS_REGISTRY_BROWSER_NAMES = {
-    "Google Chrome": "chrome",
-    "Google Chrome Canary": "chrome-canary",
+    "Ablaze Floorp": "floorp",
+    "Basilisk": "basilisk",
+    "Brave": "brave",
+    "Brave Beta": "brave-beta",
+    "Brave Nightly": "brave-nightly",
     "Chromium": "chromium",
-    "Mozilla Firefox": "firefox",
     "Firefox Developer Edition": "firefox-developer",
     "Firefox Nightly": "firefox-nightly",
-    "Opera Stable": "opera",
-    "Opera beta": "opera-beta",
-    "Opera developer": "opera-developer",
+    "Google Chrome": "chrome",
+    "Google Chrome Canary": "chrome-canary",
+    "Internet Explorer": "msie",
+    "LibreWolf": "librewolf",
     "Microsoft Edge": "msedge",
     "Microsoft Edge Beta": "msedge-beta",
     "Microsoft Edge Dev": "msedge-dev",
     "Microsoft Edge Canary": "msedge-canary",
-    "Internet Explorer": "msie",
-    "Brave": "brave",
-    "Brave Beta": "brave-beta",
-    "Brave Nightly": "brave-nightly",
+    "Mozilla Firefox": "firefox",
+    "Opera Stable": "opera",
+    "Opera beta": "opera-beta",
+    "Opera developer": "opera-developer",
+    "Pale Moon": "pale-moon",
+    "Waterfox": "waterfox",
 }
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pybrowsers"
-version = "0.10.0"
+version = "1.0.0"
 description = "Python library for detecting and launching browsers"
 authors = [
     { name = "Ronie Martinez", email = "ronmarti18@gmail.com" }


### PR DESCRIPTION
- Resolves #175 
- Ubuntu no longer support the listed browsers from the App Centre (Snap)