### PR TITLE
fix: preserve Firefox arg ordering so --private-window receives the URL

### DIFF
--- a/browsers/__init__.py
+++ b/browsers/__init__.py
@@ -75,7 +75,10 @@ def _launch(
     url_arg = []
 
     if browser == "firefox" and url is not None:  # NOTE: this does not happen on firefox-developer and firefox-nightly
-        args = ("-new-tab", url, *args)
+        if args:
+            args = (*args, url)
+        else:
+            args = ("-new-tab", url)
     elif url is not None:
         url_arg.append(url)
 

--- a/tests/test_launch.py
+++ b/tests/test_launch.py
@@ -53,3 +53,40 @@ def test_launch_chrome_test(mock_launch: mock.MagicMock) -> None:
 def test_launch_no_browser(mock_launch: mock.MagicMock) -> None:
     browsers.launch("hello", url="https://github.com/roniemartinez/browsers")
     mock_launch.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    "args, url, expected_command",
+    (
+        pytest.param(
+            ["--private-window"],
+            "https://example.com",
+            ["/usr/bin/firefox", "--private-window", "https://example.com"],
+            id="private-window-with-url",
+        ),
+        pytest.param(
+            [],
+            "https://example.com",
+            ["/usr/bin/firefox", "-new-tab", "https://example.com"],
+            id="url-only",
+        ),
+        pytest.param(
+            [],
+            None,
+            ["/usr/bin/firefox"],
+            id="no-args-no-url",
+        ),
+        pytest.param(
+            ["--private-window"],
+            None,
+            ["/usr/bin/firefox", "--private-window"],
+            id="private-window-no-url",
+        ),
+    ),
+)
+@mock.patch("subprocess.Popen")
+def test_firefox_command_construction(
+    mock_popen: mock.MagicMock, args: list[str], url: str | None, expected_command: list[str]
+) -> None:
+    browsers._launch("firefox", "/usr/bin/firefox", args, url)
+    mock_popen.assert_called_once_with(expected_command)


### PR DESCRIPTION
Fixes #224 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Firefox launch behavior so provided URLs are appended without overwriting existing launch parameters, preserving any user-supplied options.
* **Tests**
  * Added tests validating command construction for Firefox across combinations of extra options and optional URLs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->